### PR TITLE
Set default theme to light

### DIFF
--- a/code/resources/js/app.js
+++ b/code/resources/js/app.js
@@ -1,0 +1,4 @@
+// Set default theme to 'light' if not already set
+if (!localStorage.getItem('flux.appearance')) {
+    localStorage.setItem('flux.appearance', 'light');
+}

--- a/code/resources/views/livewire/settings/appearance.blade.php
+++ b/code/resources/views/livewire/settings/appearance.blade.php
@@ -5,7 +5,6 @@
         <flux:radio.group x-data variant="segmented" x-model="$flux.appearance">
             <flux:radio value="light" icon="sun">{{ __('Light') }}</flux:radio>
             <flux:radio value="dark" icon="moon">{{ __('Dark') }}</flux:radio>
-            <flux:radio value="system" icon="computer-desktop">{{ __('System') }}</flux:radio>
         </flux:radio.group>
     </x-settings.layout>
 </section>


### PR DESCRIPTION
# Pull Request

## Description

By default the `flux.appearance` localstorage variable is not set, this makes it use the system dark/light mode setting. We now manulally set `flux.appearance` to light if `flux.appearance` variable doesn't yet exist

## Pre-Merge Checklist:

- [x] All tests pass successfully
- [x] All modified pages are fully translated
