### PR TITLE
Update AssignTestsToClientModal component

### DIFF
--- a/code/app/Livewire/Staff/AssignTestsToClientModal.php
+++ b/code/app/Livewire/Staff/AssignTestsToClientModal.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Staff;
 use Livewire\Component;
 use App\Models\User;
 use App\Models\Test;
+use Illuminate\Support\Facades\Auth;
 
 class AssignTestsToClientModal extends Component
 {
@@ -26,8 +27,24 @@ class AssignTestsToClientModal extends Component
 
     public function assign(): void
     {
-        // Sync selected tests for this client
-        $this->client->tests()->sync($this->selectedTests);
+        // Only allow syncing tests that belong to the current user's organisation
+        $user = Auth::user();
+
+        if ($user && $user->organisation_id) {
+            $allowedTestIds = Test::query()
+                ->join('organisation_test', 'test.test_id', '=', 'organisation_test.test_id')
+                ->where('organisation_test.organisation_id', $user->organisation_id)
+                ->pluck('test.test_id')
+                ->toArray();
+
+            $toSync = array_values(array_intersect($this->selectedTests, $allowedTestIds));
+        } else {
+            // Superadmin or users without organisation can sync any test
+            $toSync = $this->selectedTests;
+        }
+
+        // Sync selected tests for this client (only allowed IDs)
+        $this->client->tests()->sync($toSync);
 
         $this->dispatch('modal-close', name: 'assign-tests-to-client');
         $this->dispatch('notify', message: __('Tests assigned successfully!'));
@@ -35,8 +52,22 @@ class AssignTestsToClientModal extends Component
 
     public function render()
     {
+        $user = Auth::user();
+
+        // If the user belongs to an organisation, only show tests assigned to that organisation.
+        if ($user && $user->organisation_id) {
+            $tests = Test::query()
+                ->join('organisation_test', 'test.test_id', '=', 'organisation_test.test_id')
+                ->where('organisation_test.organisation_id', $user->organisation_id)
+                ->select('test.*')
+                ->get();
+        } else {
+            // Fallback (e.g., superadmin) — show all tests
+            $tests = Test::all();
+        }
+
         return view('roles.staff.assign-tests-to-client-modal', [
-            'tests' => Test::all(), // Fetch all available tests
+            'tests' => $tests,
         ]);
     }
 


### PR DESCRIPTION
Updated the component so you only can assign tests that belong to the organisation of the mentor or admin logged in. Only pushing this file because still working on organisations management.

# Pull Request

## Description

TYPE DESCRIPTION HERE

## Pre-Merge Checklist:

- [ ] All tests pass successfully
- [ ] All modified pages are fully translated
