### PR TITLE
add clear contrast between enabled & disabled delete button for inter…

### DIFF
--- a/code/lang/en/interestfield.php
+++ b/code/lang/en/interestfield.php
@@ -21,6 +21,7 @@ return [
     'delete_success' => 'Interest field deleted successfully.',
     'delete_error' => 'Interest field cannot be deleted as it is used by a question.',
     'delete_heading' => 'Confirm Deletion',
+    'cannot_delete_used' => 'This interest field cannot be deleted because it is used in one or more questions.',
     'default' => 'Default',
     'translation_removed_success' => 'Translation removed successfully.',
     'select_valid_language' => 'Please select a valid language.',

--- a/code/lang/nl/interestfield.php
+++ b/code/lang/nl/interestfield.php
@@ -21,6 +21,7 @@ return [
     'delete_success' => 'Interessegebied succesvol verwijderd.',
     'delete_error' => 'Interessegebied kan niet worden verwijderd omdat het wordt gebruikt door een vraag.',
     'delete_heading' => 'Bevestig Verwijdering',
+    'cannot_delete_used' => 'Dit interessegebied kan niet worden verwijderd omdat het wordt gebruikt in een of meerdere vragen.',
     'default' => 'Standaard',
     'translation_removed_success' => 'Vertaling succesvol verwijderd.',
     'select_valid_language' => 'Selecteer een geldige taal.',

--- a/code/resources/views/livewire/superadmin/interest-field-manager.blade.php
+++ b/code/resources/views/livewire/superadmin/interest-field-manager.blade.php
@@ -61,14 +61,29 @@
                                     {{ __('Edit') }}
                                 </flux:button>
                             </flux:modal.trigger>
-                            <flux:button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                icon="trash"
-                                wire:click="confirmDelete({{ $interestField->interest_field_id }})">
-                                {{ __('Delete') }}
-                            </flux:button>
+
+                            @if ($interestField->questions()->exists())
+                                <flux:tooltip content="{{ __('interestfield.cannot_delete_used') }}">
+                                    <flux:button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        icon="trash"
+                                        class="cursor-not-allowed text-gray-400! text:color-gray-600"
+                                        >
+                                        {{ __('Delete') }}
+                                    </flux:button>
+                                </flux:tooltip>
+                            @else
+                                <flux:button
+                                    type="button"
+                                    variant="danger"
+                                    size="sm"
+                                    icon="trash"
+                                    wire:click="confirmDelete({{ $interestField->interest_field_id }})">
+                                    {{ __('Delete') }}
+                                </flux:button>
+                            @endif
                         </div>
                     </td>
                 </tr>

--- a/code/tests/Feature/SuperAdmin/InterestFieldManagerTest.php
+++ b/code/tests/Feature/SuperAdmin/InterestFieldManagerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature\SuperAdmin;
+
+use Tests\TestCase;
+use Livewire\Livewire;
+use App\Models\User;
+use App\Models\Role;
+use App\Models\Language;
+use App\Models\InterestField;
+use App\Models\Question;
+use App\Livewire\SuperAdmin\InterestFieldManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class InterestFieldManagerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $superAdmin;
+    protected Language $language;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // create a language (required by user factory)
+        $this->language = Language::create([
+            'language_code' => 'nl',
+            'language_name' => 'Nederlands',
+        ]);
+
+        // create roles and attach super admin role to test user
+        $superAdminRole = Role::create(['role' => Role::SUPER_ADMIN]);
+        Role::create(['role' => Role::ADMIN]);
+        Role::create(['role' => Role::MENTOR]);
+        Role::create(['role' => Role::CLIENT]);
+
+        $this->superAdmin = User::factory()->create([
+            'first_name' => 'Super',
+            'last_name' => 'Admin',
+            'username' => 'super_admin',
+            'email' => 'superadmin@example.com',
+            'language_id' => $this->language->language_id,
+            'organisation_id' => 1,
+            'active' => true,
+            'vision_type' => 'normal',
+        ]);
+
+        $this->superAdmin->roles()->attach($superAdminRole->role_id);
+    }
+
+    public function test_can_create_interest_field(): void
+    {
+        Livewire::actingAs($this->superAdmin)
+            ->test(InterestFieldManager::class)
+            ->call('startCreate')
+            ->set('form.name', 'My Interest')
+            ->set('form.description', 'Description for my interest')
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('interest_field', [
+            'name' => 'My Interest',
+            'description' => 'Description for my interest',
+        ]);
+    }
+
+    public function test_can_edit_interest_field(): void
+    {
+        $interest = InterestField::factory()->create([
+            'name' => 'Original',
+            'description' => 'Original description',
+        ]);
+
+        Livewire::actingAs($this->superAdmin)
+            ->test(InterestFieldManager::class)
+            ->call('startEdit', $interest->interest_field_id)
+            ->set('form.name', 'Updated')
+            ->set('form.description', 'Updated description')
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('interest_field', [
+            'interest_field_id' => $interest->interest_field_id,
+            'name' => 'Updated',
+        ]);
+    }
+
+    public function test_prevents_delete_when_used_by_question(): void
+    {
+        $interest = InterestField::factory()->create();
+
+        // create a question that references the interest field
+        Question::factory()->create([
+            'interest_field_id' => $interest->interest_field_id,
+            'question_number' => 1,
+        ]);
+
+        Livewire::actingAs($this->superAdmin)
+            ->test(InterestFieldManager::class)
+            ->call('confirmDelete', $interest->interest_field_id)
+            ->call('deleteInterestField');
+
+        // record should still exist
+        $this->assertDatabaseHas('interest_field', [
+            'interest_field_id' => $interest->interest_field_id,
+        ]);
+    }
+
+    public function test_can_delete_unused_interest_field(): void
+    {
+        $interest = InterestField::factory()->create();
+
+        Livewire::actingAs($this->superAdmin)
+            ->test(InterestFieldManager::class)
+            ->call('confirmDelete', $interest->interest_field_id)
+            ->call('deleteInterestField');
+
+        $this->assertDatabaseMissing('interest_field', [
+            'interest_field_id' => $interest->interest_field_id,
+        ]);
+    }
+}


### PR DESCRIPTION
…est field

# Pull Request

## Description

Add clear contrast between enabled & disabled delete button. Disabled delete button shows a tooltip & mouse cursor changes to 'not-valid'. Enabled button turns red.

## Pre-Merge Checklist:

- [x] All tests pass successfully
- [x] All modified pages are fully translated
