### PR TITLE
fix edit client not working when inactive clients are shown

### DIFF
--- a/code/resources/views/livewire/mentor/clients-manager-table.blade.php
+++ b/code/resources/views/livewire/mentor/clients-manager-table.blade.php
@@ -1,5 +1,6 @@
 @props([
 'records' => [],
+'tableKey' => 'active',
 ])
 
 <div class="overflow-x-auto rounded-lg shadow-sm">
@@ -16,7 +17,7 @@
         </thead>
         <tbody class="divide-y divide-gray-800 text-sm text-gray-700 dark:bg-zinc-900 dark:text-gray-50">
             @forelse ($records as $client)
-            <tr wire:key="client-{{ $client->user_id }}" class="hover:bg-gray-50 hover:dark:bg-zinc-600">
+            <tr wire:key="client-{{ $tableKey }}-{{ $client->user_id }}" class="hover:bg-gray-50 hover:dark:bg-zinc-600">
                 <td class="px-4 py-3">{{ $client->first_name }}</td>
                 <td class="px-4 py-3">{{ $client->last_name }}</td>
                 <td class="px-4 py-3 font-mono">{{ $client->username }}</td>

--- a/code/resources/views/livewire/mentor/clients-manager.blade.php
+++ b/code/resources/views/livewire/mentor/clients-manager.blade.php
@@ -31,7 +31,7 @@
         </div>
     </div>
 
-    @include('livewire.mentor.clients-manager-table', ['records' => $records])
+    @include('livewire.mentor.clients-manager-table', ['records' => $records, 'tableKey' => 'active'])
 
     <div class="flex flex-wrap items-center gap-3">
         <flux:button
@@ -45,7 +45,7 @@
     </div>
     @if ($showInactivated)
     <div class="mt-4">
-        @include('livewire.mentor.clients-manager-table', ['records' => $inactivatedClients])
+        @include('livewire.mentor.clients-manager-table', ['records' => $inactivatedClients, 'tableKey' => 'inactive'])
     </div>
     @endif
 


### PR DESCRIPTION
# Pull Request

## Description

Fix the edit client modal not opening when inactive clients are shown

## Pre-Merge Checklist:

- [x] All tests pass successfully
- [x] All modified pages are fully translated
